### PR TITLE
Replace UpdateDeviceStatus with UpsertDeviceStatus

### DIFF
--- a/api/http/device.go
+++ b/api/http/device.go
@@ -157,7 +157,7 @@ func (h DeviceController) Connect(c *gin.Context) {
 	})
 
 	// update the device status on websocket opening
-	err = h.app.UpdateDeviceStatus(
+	err = h.app.UpsertDeviceStatus(
 		ctx, idata.Tenant,
 		idata.Subject, model.DeviceStatusConnected,
 	)
@@ -167,7 +167,7 @@ func (h DeviceController) Connect(c *gin.Context) {
 	}
 	defer func() {
 		// update the device status on websocket closing
-		err = h.app.UpdateDeviceStatus(
+		err = h.app.UpsertDeviceStatus(
 			ctx, idata.Tenant,
 			idata.Subject, model.DeviceStatusDisconnected,
 		)

--- a/api/http/device_test.go
+++ b/api/http/device_test.go
@@ -57,7 +57,7 @@ func TestDeviceConnect(t *testing.T) {
 				JWTDeviceID,
 			).Return(make(<-chan *model.Message), nil)
 
-			app.On("UpdateDeviceStatus",
+			app.On("UpsertDeviceStatus",
 				mock.MatchedBy(func(_ context.Context) bool {
 					return true
 				}),
@@ -66,7 +66,7 @@ func TestDeviceConnect(t *testing.T) {
 				model.DeviceStatusConnected,
 			).Return(nil)
 
-			app.On("UpdateDeviceStatus",
+			app.On("UpsertDeviceStatus",
 				mock.MatchedBy(func(_ context.Context) bool {
 					return true
 				}),

--- a/app/app.go
+++ b/app/app.go
@@ -103,7 +103,7 @@ func (a *DeviceConnectApp) GetDevice(
 	return device, nil
 }
 
-// DeleteDevice decomissions a new tenant
+// DeleteDevice decommissions a device
 func (a *DeviceConnectApp) DeleteDevice(ctx context.Context, tenantID, deviceID string) error {
 	return a.store.DeleteDevice(ctx, tenantID, deviceID)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -44,7 +44,7 @@ type App interface {
 	ProvisionDevice(ctx context.Context, tenantID string, device *model.Device) error
 	GetDevice(ctx context.Context, tenantID string, deviceID string) (*model.Device, error)
 	DeleteDevice(ctx context.Context, tenantID string, deviceID string) error
-	UpdateDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error
+	UpsertDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error
 	PrepareUserSession(ctx context.Context, tenantID string, userID string, deviceID string) (*model.Session, error)
 	UpdateUserSessionStatus(ctx context.Context, tenantID string, sessionID string, status string) error
 	PublishMessageFromDevice(ctx context.Context, tenantID string, deviceID string, message *model.Message) error
@@ -79,7 +79,7 @@ func (a *DeviceConnectApp) ProvisionTenant(ctx context.Context, tenant *model.Te
 	return a.store.ProvisionTenant(ctx, tenant.TenantID)
 }
 
-// ProvisionDevice provisions a new tenant
+// ProvisionDevice provisions a new device
 func (a *DeviceConnectApp) ProvisionDevice(
 	ctx context.Context,
 	tenantID string,
@@ -103,17 +103,17 @@ func (a *DeviceConnectApp) GetDevice(
 	return device, nil
 }
 
-// DeleteDevice provisions a new tenant
+// DeleteDevice decomissions a new tenant
 func (a *DeviceConnectApp) DeleteDevice(ctx context.Context, tenantID, deviceID string) error {
 	return a.store.DeleteDevice(ctx, tenantID, deviceID)
 }
 
-// UpdateDeviceStatus provisions a new tenant
-func (a *DeviceConnectApp) UpdateDeviceStatus(
+// UpsertDeviceStatus upserts the connection status of a device
+func (a *DeviceConnectApp) UpsertDeviceStatus(
 	ctx context.Context,
 	tenantID, deviceID, status string,
 ) error {
-	return a.store.UpdateDeviceStatus(ctx, tenantID, deviceID, status)
+	return a.store.UpsertDeviceStatus(ctx, tenantID, deviceID, status)
 }
 
 // PrepareUserSession prepares a new user session

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -165,13 +165,13 @@ func TestGetDevice(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-func TestUpdateDeviceStatus(t *testing.T) {
+func TestUpsertDeviceStatus(t *testing.T) {
 	err := errors.New("error")
 	const tenantID = "1234"
 	const deviceID = "abcd"
 
 	store := &store_mocks.DataStore{}
-	store.On("UpdateDeviceStatus",
+	store.On("UpsertDeviceStatus",
 		mock.MatchedBy(func(ctx context.Context) bool {
 			return true
 		}),
@@ -183,7 +183,7 @@ func TestUpdateDeviceStatus(t *testing.T) {
 	app := NewDeviceConnectApp(store, nil, nil)
 
 	ctx := context.Background()
-	res := app.UpdateDeviceStatus(ctx, tenantID, deviceID, "anything")
+	res := app.UpsertDeviceStatus(ctx, tenantID, deviceID, "anything")
 	assert.Equal(t, err, res)
 
 	store.AssertExpectations(t)

--- a/app/mocks/App.go
+++ b/app/mocks/App.go
@@ -225,8 +225,8 @@ func (_m *App) SubscribeMessagesFromManagement(ctx context.Context, tenantID str
 	return r0, r1
 }
 
-// UpdateDeviceStatus provides a mock function with given fields: ctx, tenantID, deviceID, status
-func (_m *App) UpdateDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error {
+// UpsertDeviceStatus provides a mock function with given fields: ctx, tenantID, deviceID, status
+func (_m *App) UpsertDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error {
 	ret := _m.Called(ctx, tenantID, deviceID, status)
 
 	var r0 error

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -27,7 +27,7 @@ type DataStore interface {
 	ProvisionDevice(ctx context.Context, tenantID string, deviceID string) error
 	DeleteDevice(ctx context.Context, tenantID, deviceID string) error
 	GetDevice(ctx context.Context, tenantID, deviceID string) (*model.Device, error)
-	UpdateDeviceStatus(ctx context.Context, tenantID, deviceID, status string) error
+	UpsertDeviceStatus(ctx context.Context, tenantID, deviceID, status string) error
 	UpsertSession(ctx context.Context, tenantID, userID, devID string) (*model.Session, error)
 	GetSession(ctx context.Context, tenantID, sessionID string) (*model.Session, error)
 	UpdateSessionStatus(ctx context.Context, tenantID, sessionID, status string) error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -129,8 +129,8 @@ func (_m *DataStore) ProvisionTenant(ctx context.Context, tenantID string) error
 	return r0
 }
 
-// UpdateDeviceStatus provides a mock function with given fields: ctx, tenantID, deviceID, status
-func (_m *DataStore) UpdateDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error {
+// UpsertDeviceStatus provides a mock function with given fields: ctx, tenantID, deviceID, status
+func (_m *DataStore) UpsertDeviceStatus(ctx context.Context, tenantID string, deviceID string, status string) error {
 	ret := _m.Called(ctx, tenantID, deviceID, status)
 
 	var r0 error

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -204,8 +204,8 @@ func (db *DataStoreMongo) GetDevice(
 	return device, nil
 }
 
-// UpdateDeviceStatus updates a device status
-func (db *DataStoreMongo) UpdateDeviceStatus(
+// UpsertDeviceStatus upserts the connection status of a device
+func (db *DataStoreMongo) UpsertDeviceStatus(
 	ctx context.Context,
 	tenantID string,
 	deviceID string,
@@ -215,6 +215,8 @@ func (db *DataStoreMongo) UpdateDeviceStatus(
 	coll := db.client.Database(dbname).Collection(DevicesCollectionName)
 
 	updateOpts := &mopts.UpdateOptions{}
+	updateOpts.SetUpsert(true)
+
 	_, err := coll.UpdateOne(ctx,
 		bson.M{"_id": deviceID},
 		bson.M{

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -76,7 +76,7 @@ func TestProvisionAndDeleteDevice(t *testing.T) {
 	assert.Nil(t, device)
 }
 
-func TestUpdateDeviceStatus(t *testing.T) {
+func TestUpsertDeviceStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping TestPing in short mode.")
 	}
@@ -96,10 +96,18 @@ func TestUpdateDeviceStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, model.DeviceStatusDisconnected, device.Status)
 
-	err = ds.UpdateDeviceStatus(ctx, tenantID, deviceID, model.DeviceStatusConnected)
+	err = ds.UpsertDeviceStatus(ctx, tenantID, deviceID, model.DeviceStatusConnected)
 	assert.NoError(t, err)
 
 	device, err = ds.GetDevice(ctx, tenantID, deviceID)
+	assert.NoError(t, err)
+	assert.Equal(t, model.DeviceStatusConnected, device.Status)
+
+	const anotherDeviceID = "efgh"
+	err = ds.UpsertDeviceStatus(ctx, tenantID, anotherDeviceID, model.DeviceStatusConnected)
+	assert.NoError(t, err)
+
+	device, err = ds.GetDevice(ctx, tenantID, anotherDeviceID)
 	assert.NoError(t, err)
 	assert.Equal(t, model.DeviceStatusConnected, device.Status)
 }

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -110,6 +110,13 @@ func TestUpsertDeviceStatus(t *testing.T) {
 	device, err = ds.GetDevice(ctx, tenantID, anotherDeviceID)
 	assert.NoError(t, err)
 	assert.Equal(t, model.DeviceStatusConnected, device.Status)
+
+	err = ds.UpsertDeviceStatus(ctx, tenantID, anotherDeviceID, model.DeviceStatusDisconnected)
+	assert.NoError(t, err)
+
+	device, err = ds.GetDevice(ctx, tenantID, anotherDeviceID)
+	assert.NoError(t, err)
+	assert.Equal(t, model.DeviceStatusDisconnected, device.Status)
 }
 
 func TestUpsertSession(t *testing.T) {


### PR DESCRIPTION
As we cannot rely on device provisioning because we can potentially have
existing devices in the database, before the introduction of device
connect, it is safer to replace the UpdateDeviceStatus function with an
equivalent one which performs an upsert instead.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>