### PR TITLE
api: Attach "user_id" property to forwarded websocket messages

### DIFF
--- a/api/http/management.go
+++ b/api/http/management.go
@@ -45,6 +45,10 @@ var (
 
 const channelSize = 25 // TODO make configurable
 
+const (
+	PropertyUserID = "user_id"
+)
+
 // ManagementController container for end-points
 type ManagementController struct {
 	app  app.App
@@ -324,6 +328,10 @@ func (h ManagementController) ConnectServeWS(
 		switch m.Header.Proto {
 		case ws.ProtoTypeShell:
 			m.Header.SessionID = sess.ID
+			if m.Header.Properties == nil {
+				m.Header.Properties = make(map[string]interface{})
+			}
+			m.Header.Properties[PropertyUserID] = sess.UserID
 			data, _ = msgpack.Marshal(m)
 		default:
 			// TODO: Handle protocol violation

--- a/api/http/management_test.go
+++ b/api/http/management_test.go
@@ -331,6 +331,9 @@ func TestManagementConnect(t *testing.T) {
 				err = msgpack.Unmarshal(natsMsg.Data, &rMsg)
 				if assert.NoError(t, err) {
 					msg.Header.SessionID = tc.SessionID
+					msg.Header.Properties = map[string]interface{}{
+						"user_id": tc.Identity.Subject,
+					}
 					assert.Equal(t, msg, rMsg)
 				}
 			case <-time.After(time.Second * 5):

--- a/tests/common.py
+++ b/tests/common.py
@@ -115,6 +115,7 @@ def management_api_with_params(user_id, plan=None, tenant_id=None):
 
 def management_api_connect(
     device_id: str,
+    user_id: str = None,
     tenant_id: str = None,
     plan: str = None,
     api_conf: management_api.Configuration = None,
@@ -122,7 +123,7 @@ def management_api_connect(
 ):
     if api_conf is None:
         api_conf = management_api.Configuration.get_default_copy()
-    jwt = make_user_token(tenant_id=tenant_id, plan=plan)
+    jwt = make_user_token(user_id=user_id, tenant_id=tenant_id, plan=plan)
     url = (
         re.sub(r"^http(s?://.+$)", r"ws\1", api_conf.host).rstrip("/")
         + f"/devices/{device_id}/connect"

--- a/tests/tests/test_connect.py
+++ b/tests/tests/test_connect.py
@@ -21,9 +21,8 @@ class _TestConnect:
         """
 
         dev = Device(tenant_id=tenant_id)
-        api_mgmt = management_api_with_params(
-            user_id=str(uuid.uuid4()), tenant_id=tenant_id
-        )
+        user_id = str(uuid.uuid4())
+        api_mgmt = management_api_with_params(user_id=user_id, tenant_id=tenant_id)
         try:
             api_mgmt.connect(
                 "00000000-0000-0000-0000-000000000000",
@@ -74,7 +73,9 @@ class _TestConnect:
             else:
                 raise Exception("Expected status code 101")
 
-            with management_api_connect(dev.id, tenant_id=tenant_id) as user_conn:
+            with management_api_connect(
+                dev.id, user_id=user_id, tenant_id=tenant_id
+            ) as user_conn:
                 user_conn.send(
                     msgpack.dumps(
                         {
@@ -90,14 +91,16 @@ class _TestConnect:
                 rsp = msgpack.loads(msg)
                 assert "hdr" in rsp, "Message does not contain header"
                 assert (
-                    "sid" in rsp["hdr"],
-                    "Forwarded message should contain session ID",
-                )
+                    "sid" in rsp["hdr"]
+                ), "Forwarded message should contain session ID"
                 assert rsp == {
                     "hdr": {
                         "proto": 1,
                         "typ": "start",
-                        "props": {"status": "ok"},
+                        "props": {
+                            "status": "ok",
+                            "user_id": user_id,
+                        },
                         "sid": rsp["hdr"]["sid"],
                     },
                 }


### PR DESCRIPTION
In addition to attaching session id, deviceconnect will add an
additional field "user_id" to the "hdr.props" of the ProtoMsg.
changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>