### PR TITLE
Send shell stop messages on disconnection only if remote terminal is on

### DIFF
--- a/model/session.go
+++ b/model/session.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -74,4 +74,9 @@ func (sess Session) Validate() error {
 		validation.Field(&sess.DeviceID, validation.Required),
 		validation.Field(&sess.StartTS, validation.Required),
 	)
+}
+
+// ActiveSession stores the data about an active session in memory
+type ActiveSession struct {
+	RemoteTerminal bool
 }


### PR DESCRIPTION
In the past, the only supported protocol in deviceconnect was the remote
terminal. Now that we plan to extend deviceconnect to additional
protocols, we need to be sure we are sending the stop message only if
the session is used to run a remote terminal.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>