### PR TITLE
docs: Initialize AsyncAPI docs for shell and file transfer

### DIFF
--- a/docs/asyncapi/deviceconnect.yml
+++ b/docs/asyncapi/deviceconnect.yml
@@ -1,0 +1,612 @@
+asyncapi: "1.2.0"
+info:
+  title: Mender Connect API
+  version: "1.0.0"
+
+servers:
+  - url: https://mender.io/api/management/v1/deviceconnect/connect
+    scheme: https
+    schemeVersion: "1.1"
+security:
+  - ManagementJWT: []
+
+
+x-id: "urn:io:mender:ws:api"
+x-defaultContentType: vnd-protomsg/msgpack
+
+events:
+  send: # Client -> Device
+    # Session control messages
+    - $ref: "#/components/messages/accept"
+    - $ref: "#/components/messages/close"
+    - $ref: "#/components/messages/open"
+    - $ref: "#/components/messages/ping"
+    - $ref: "#/components/messages/pong"
+    - $ref: "#/components/messages/error"
+
+    # Shell
+    - $ref: "#/components/messages/shell_new"
+    - $ref: "#/components/messages/shell_stop"
+    - $ref: "#/components/messages/shell_ping"
+    - $ref: "#/components/messages/shell_pong"
+    - $ref: "#/components/messages/shell_resize"
+    - $ref: "#/components/messages/shell_command"
+
+    # File transfer
+    - $ref: "#/components/messages/file_stat"
+    - $ref: "#/components/messages/file_download"
+    - $ref: "#/components/messages/file_upload"
+    - $ref: "#/components/messages/file_chunk"
+    - $ref: "#/components/messages/file_ack"
+
+
+  receive: # Client <- Device
+    # Session control messages
+    - $ref: "#/components/messages/ping"
+    - $ref: "#/components/messages/pong"
+    - $ref: "#/components/messages/close"
+    - $ref: "#/components/messages/error"
+
+    # Shell
+    - $ref: "#/components/messages/shell_command"
+    - $ref: "#/components/messages/shell_stop"
+
+    # File transfer
+    - $ref: "#/components/messages/file_info"
+    - $ref: "#/components/messages/file_chunk"
+
+
+x-proto-types: &proto-types
+  # List of aliases for convenience - ignored by asyncapi parser
+  - &proto-type-shell         1
+  - &proto-type-file-transfer 2
+  - &proto-type-port-forward  3
+  - &proto-type-mender-client 4
+  - &proto-type-control       65535
+
+x-hdr-values:
+  # Shorthand header values
+  proto:
+    - &proto-shell
+      description: Protocol type (constant).
+      type: integer
+      format: uint16
+      enum: [*proto-type-shell]
+    - &proto-file-transfer
+      description: Protocol type (constant).
+      type: integer
+      format: uint16
+      enum: [*proto-type-file-transfer]
+    - &proto-port-forward
+      description: Protocol type (constant).
+      type: integer
+      format: uint16
+      enum: [*proto-type-port-forward]
+    - &proto-mender-client
+      description: Protocol type (constant).
+      type: integer
+      format: uint16
+      enum: [*proto-type-mender-client]
+    - &proto-control
+      description: Protocol type (constant).
+      type: integer
+      format: uint16
+      enum: [*proto-type-control]
+
+  sid: &session-id
+    description: Unique session identifier.
+    type: string
+    format: uuid
+
+
+x-shell-statuses: &shell-statuses
+  # Shell specific status codes
+  - &shell_normal 1
+  - &shell_error  2
+  - &shell_ctrl   3
+
+x-message-tags: &message-tags
+  - &tag-shell
+    name: Shell
+    description: Mender shell protocol.
+  - &tag-file-transfer
+    name: File transfer
+    description: Mender file transfer protocol.
+  - &tag-control
+    name: Session control
+    description: Session control messages.
+
+components:
+  securitySchemes:
+    ManagementJWT:
+      type: httpApiKey
+      name: jwt
+      in: cookie
+
+  messages:
+    ## Message format:
+    # <message>:
+    #   summary:
+    #     @string - A short summary of what the message is.
+    #   description:
+    #     @string - Verbose (Markdown) explanation of the message.
+    #   headers:
+    #     @schema - goes into ProtoMsg["hdr"]
+    #   payload:
+    #     @schema - goes into ProtoMsg["body"] (optional)
+    #   tags:
+    #     list(@tag)
+
+    error:
+      summary: Error message.
+      tags: *message-tags
+      headers:
+        type: object
+        properties:
+          proto:
+            description: Protocol type (constant).
+            type: integer
+            format: uint16
+            enum: *proto-types
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["error"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+      payload:
+        $ref: "#/components/schemas/error"
+
+    accept:
+      summary: Accept a new session request (#open)
+      tags:
+        - *tag-control
+      headers:
+        properties:
+          proto: *proto-control
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["accept"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+      payload:
+        properties:
+          version:
+            description: |-
+              Accepted ProtoMsg version to use for the session.
+            type: integer
+          proto:
+            description: |-
+              List of protocols open for the session.
+            type: array
+            items:
+              type: integer
+              format: uint16
+        required:
+          - version
+          - proto
+
+    close:
+      summary: Close session.
+      description: |-
+        Upon receiving a close message, all communication on the session MUST stop.
+      tags:
+        - *tag-control
+      headers:
+        type: object
+        properties:
+          proto: *proto-control
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["close"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+
+    open:
+      summary: Initiate a new session
+      tags:
+        - *tag-control
+      headers:
+        properties:
+          proto: *proto-control
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["open"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+      payload:
+        properties:
+          versions:
+            description: |-
+              List of ProtoMsg versions supported by the client.
+            type: array
+            items:
+              type: integer
+
+    ping:
+      summary: Session ping.
+      description: |-
+        Session keep-alive ping message.
+      tags:
+        - *tag-control
+      headers:
+        type: object
+        properties:
+          proto: *proto-control
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["ping"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+
+
+    pong:
+      summary: Session pong.
+      description: Response to ping messages.
+      tags:
+        - *tag-control
+      headers:
+        type: object
+        properties:
+          proto: *proto-control
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["pong"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+
+    shell_new:
+      summary: Open a new shell session.
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["new"]
+          sid: *session-id
+        required:
+          - proto
+          - typ
+          - sid
+
+    shell_stop:
+      summary: Close shell session.
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["stop"]
+          sid: *session-id
+          props: &ctrl-msg-props
+            description: Predefined header properties.
+            type: object
+            properties:
+              status:
+                description: Message status.
+                type: integer
+                enum: [*shell_ctrl]
+            required:
+              - status
+        required:
+          - proto
+          - typ
+          - sid
+          - props
+
+    shell_ping:
+      summary: Ping message
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["ping"]
+          sid: *session-id
+          props: *ctrl-msg-props
+        required:
+          - proto
+          - typ
+          - sid
+          - props
+
+    shell_pong:
+      summary: Pong message
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["pong"]
+          sid: *session-id
+
+    shell_resize:
+      summary: Resize shell control message.
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["resize"]
+          sid: *session-id
+          props: *ctrl-msg-props
+
+    shell_command:
+      summary: Shell command.
+      tags:
+        - *tag-shell
+      headers:
+        type: object
+        properties:
+          proto: *proto-shell
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["shell"]
+          sid: *session-id
+          props:
+            description: Predefined header properties.
+            type: object
+            properties:
+              status:
+                description: Message status.
+                type: integer
+                enum: *shell-statuses
+      payload:
+        type: string
+        format: binary
+        description: |
+          Binary standard input to the shell.
+
+    file_stat:
+      summary: Get file info.
+      description: |-
+        Run stat(2) on the path provided in the payload and return a file_info object.
+      tags:
+        - *tag-file-transfer
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["file_stat"]
+          sid: *session-id
+      payload:
+        type: object
+        properties:
+          path:
+            type: string
+
+    file_info:
+      summary: File info.
+      description: |-
+        Returned in response to a file_stat request.
+      tags:
+        - *tag-file-transfer
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["file_info"]
+          sid: *session-id
+      payload:
+        $ref: "#/components/schemas/file_info"
+
+    file_upload:
+      summary: Upload file.
+      description: |-
+        Upload a file to device. File contents is provided using file_chunks.
+      tags:
+        - *tag-file-transfer
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["put_file"]
+          sid: *session-id
+      payload:
+        $ref: "#/components/schemas/file_upload"
+
+    file_download:
+      summary: Fetch file from device.
+      tags:
+        - *tag-file-transfer
+      description: |-
+        After a @file_download request is sent to the device, the device will
+        respond with a stream of @file_chunk objects on success. Otherwise an
+        @error is returned with a description of the error.
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["get_file"]
+          sid: *session-id
+      payload:
+        $ref: "#/components/schemas/file_download"
+
+    file_chunk:
+      summary: Chunk of file contents
+      tags:
+        - *tag-file-transfer
+      description: |
+        This message carries a chunk of file contents for upload/downloading
+        file objects between the client and device.
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["file_chunk"]
+          sid: *session-id
+          props:
+            type: object
+            properties:
+              offset:
+                description: File offset.
+                type: integer
+                format: uint64
+            required:
+                - offset
+      payload:
+        description: File data.
+        type: string
+        format: binary
+
+    file_ack:
+      summary: File transfer acknowledge message
+      description: |-
+        An ack message is send in response to file_chunk and file_upload messages.
+      headers:
+        type: object
+        properties:
+          proto: *proto-file-transfer
+          typ:
+            description: Message type (constant).
+            type: string
+            enum: ["file_chunk"]
+          sid: *session-id
+          props:
+            description: |-
+              Props depend on the message being acknowledged.
+              For file_chunks, an "offset" property should identify the updated file offset after consuming the chunk.
+            type: object
+            additionalProperties: true
+
+
+  schemas:
+    error:
+      type: object
+      properties:
+        err:
+          description: Error message.
+          type: string
+        msgtype:
+          description: Message type that caused the error.
+          type: string
+        msgid:
+          description: Message ID of the message causing the error.
+        close:
+          description: Set to true if the error is terminating the session.
+          type: boolean
+      required:
+        - err
+
+    file_info:
+      description: |-
+        File info provides the information returned by a file_stat request.
+      type: object
+      required:
+        - path
+        - size
+        - modtime
+      properties:
+        path:
+          description: File path.
+          type: string
+        size:
+          description: Size in bytes.
+          type: integer
+        mode:
+          description: File mode and permissions.
+          type: integer
+          format: uint32
+        uid:
+          description: File owner ID.
+          type: integer
+          format: uint32
+        gid:
+          description: File group ID.
+          type: integer
+          format: uint32
+        modtime:
+          description: Last modified timestamp.
+          type: string
+          format: date-time
+
+    file_upload:
+      description: |-
+        Schema for file_upload request.
+      type: object
+      properties:
+        path:
+          description: File path.
+          type: string
+        mode:
+          description: File permission bits.
+          type: integer
+          format: uint32
+        uid:
+          description: File owner ID.
+          type: integer
+          format: uint32
+        gid:
+          description: File group ID.
+          type: integer
+          format: uint32
+      required:
+        - path
+
+    file_download:
+      type: object
+      required:
+        - path
+      properties:
+        path:
+          description: File path.
+          type: string


### PR DESCRIPTION
Initialized api specs for shell and file transfer based on the
structures in mendersoftware/go-lib-micro.

After comparing the structures with the design document I realized
that the file transfer protocol is most likely subject to change which
is why I stopped at this point.

I've already tested rendering markdown with mermade/widdershins
and discovered that we will likely need to update the template for rendering
these kinds of api specs.