### PR TITLE
QA-235: pipeline: Switch to static checks by golangci-lint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-static.yml'
+    file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-unittests.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -27,16 +27,6 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
-
-test:static:
-  image: golang:1.15
-  needs: []
-  before_script:
-    - |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-           sh -s -- -b $(go env GOPATH)/bin v1.31.0
-  script:
-    - golangci-lint run -v
 
 test:unit:
   image: golang:1.15

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - errcheck
     - gocyclo
     - gofmt
+    - goimports
     - gosimple
     - govet
     - ineffassign
@@ -32,10 +33,15 @@ linters:
 
 linters-settings:
   gocyclo:
-    min-complexity: 20 # default is 30.
+    # default is 30.
+    min-complexity: 20
+
+  goimports:
+    local-prefixes:
+      "github.com/mendersoftware/deviceconnect"
 
   lll:
     # max line length, lines longer will be reported. Default is 120.
     line-length: 100
     # tab width in spaces. Default to 1.
-    tab-width: 8
+    tab-width: 4

--- a/api/http/status.go
+++ b/api/http/status.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/mendersoftware/deviceconnect/app"
-	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/go-lib-micro/log"
+
+	"github.com/mendersoftware/deviceconnect/app"
 )
 
 const (

--- a/app/playback.go
+++ b/app/playback.go
@@ -15,8 +15,9 @@
 package app
 
 import (
-	"github.com/nats-io/nats.go"
 	"time"
+
+	"github.com/nats-io/nats.go"
 )
 
 const (

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -22,14 +22,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mendersoftware/deviceconnect/app"
-	"github.com/mendersoftware/go-lib-micro/log"
-	"github.com/mendersoftware/go-lib-micro/ws"
-	"github.com/mendersoftware/go-lib-micro/ws/shell"
-	"github.com/vmihailenco/msgpack/v5"
-
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/vmihailenco/msgpack/v5"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mopts "go.mongodb.org/mongo-driver/mongo/options"
@@ -37,9 +32,13 @@ import (
 
 	"github.com/mendersoftware/go-lib-micro/config"
 	"github.com/mendersoftware/go-lib-micro/identity"
+	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
 	mstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/mendersoftware/go-lib-micro/ws"
+	"github.com/mendersoftware/go-lib-micro/ws/shell"
 
+	"github.com/mendersoftware/deviceconnect/app"
 	dconfig "github.com/mendersoftware/deviceconnect/config"
 	"github.com/mendersoftware/deviceconnect/model"
 	"github.com/mendersoftware/deviceconnect/store"

--- a/store/mongo/recording_writer.go
+++ b/store/mongo/recording_writer.go
@@ -15,10 +15,11 @@
 package mongo
 
 import (
+	"io"
+
 	"github.com/mendersoftware/go-lib-micro/ws"
 	"github.com/mendersoftware/go-lib-micro/ws/shell"
 	"github.com/vmihailenco/msgpack/v5"
-	"io"
 )
 
 type RecordingWriter struct {


### PR DESCRIPTION
Modify the existing .golangci.yml to follow standard and fix goimports
linting issues.