### PR TITLE
MEN-5718: Fix broken document migration

### DIFF
--- a/store/mongo/migration_2_0_1_test.go
+++ b/store/mongo/migration_2_0_1_test.go
@@ -31,11 +31,7 @@ type index struct {
 	ExpireAfter *int           `bson:"expireAfterSeconds"`
 }
 
-func TestMigration_2_0_0(t *testing.T) {
-	m := &migration_2_0_0{
-		client: db.Client(),
-		db:     DbName,
-	}
+func TestMigration_2_0_1(t *testing.T) {
 	db := db.Client().Database(DbName)
 
 	collDevs := db.Collection(DevicesCollectionName)
@@ -63,7 +59,9 @@ func TestMigration_2_0_0(t *testing.T) {
 		}())
 	require.NoError(t, err)
 
-	err = Migrate(ctx, DbName, "2.0.0", db.Client(), true)
+	// NOTE: We're using 2.0.1 since it's the same migration, thus verifying
+	//       that the migration is reentrant.
+	err = Migrate(ctx, DbName, "2.0.1", db.Client(), true)
 	require.NoError(t, err)
 
 	collNames, err := db.ListCollectionNames(ctx, bson.D{})
@@ -118,7 +116,6 @@ func TestMigration_2_0_0(t *testing.T) {
 			}
 		}
 	}
-	assert.Equal(t, "2.0.0", m.Version().String())
 
 	actual, err := collDevs.CountDocuments(ctx, bson.D{
 		{Key: mstore.FieldTenantID, Value: bson.D{{Key: "$exists", Value: false}}},

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// DbVersion is the current schema version
-	DbVersion = "2.0.0"
+	DbVersion = "2.0.1"
 
 	// DbName is the database name
 	DbName = "deviceconnect"
@@ -68,10 +68,11 @@ func Migrate(ctx context.Context,
 				client: client,
 				db:     dbName,
 			},
-			&migration_2_0_0{
+			&migration_2_0_1{
 				client: client,
 				db:     dbName,
 			},
+			// NOTE: Future migrations need only be applied to DbName
 		}
 		err = m.Apply(ctx, *ver, migrations)
 		if err != nil {

--- a/store/mongo/migrations.go
+++ b/store/mongo/migrations.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -46,26 +47,36 @@ func Migrate(ctx context.Context,
 		return errors.Wrap(err, "failed to parse service version")
 	}
 
-	m := migrate.SimpleMigrator{
-		Client:      client,
-		Db:          db,
-		Automigrate: automigrate,
-	}
-
-	migrations := []migrate.Migration{
-		&migration_1_0_0{
-			client: client,
-			db:     db,
-		},
-		&migration_2_0_0{
-			client: client,
-			db:     db,
-		},
-	}
-
-	err = m.Apply(ctx, *ver, migrations)
+	dbNames, err := client.ListDatabaseNames(ctx, bson.D{
+		{Key: "name", Value: bson.D{
+			{Key: "$regex", Value: "^" + DbName + "-"},
+		}},
+	})
 	if err != nil {
-		return errors.Wrap(err, "failed to apply migrations")
+		return err
+	}
+
+	for _, dbName := range append([]string{DbName}, dbNames...) {
+		m := migrate.SimpleMigrator{
+			Client:      client,
+			Db:          dbName,
+			Automigrate: automigrate,
+		}
+
+		migrations := []migrate.Migration{
+			&migration_1_0_0{
+				client: client,
+				db:     dbName,
+			},
+			&migration_2_0_0{
+				client: client,
+				db:     dbName,
+			},
+		}
+		err = m.Apply(ctx, *ver, migrations)
+		if err != nil {
+			return errors.Wrap(err, "failed to apply migrations")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes the document migration for collection with more than 255 documents and applies the migration to legacy (multiple namespaces) layout.