### PR TITLE
ci: Replace Coveralls with Codecov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,29 +92,21 @@ publish:acceptance:
   stage: publish
   except:
     - /^saas-[a-zA-Z0-9.-]+$/
-  image: golang:1.18
+  image: curlimages/curl-base
   needs:
     - job: test:acceptance
       artifacts: true
-  before_script:
-    - GO111MODULE=off go get github.com/mattn/goveralls
-    # Coveralls env variables:
-    #  According to https://docs.coveralls.io/supported-ci-services
-    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
-    #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
-    #  and pass few others as command line arguments.
-    #  See also https://docs.coveralls.io/api-reference
-    - export CI_BRANCH=${CI_COMMIT_BRANCH}
   script:
-    - goveralls
-      -repotoken ${COVERALLS_TOKEN}
-      -service gitlab-ci
-      -jobid $CI_PIPELINE_ID
-      -covermode atomic
-      -flagname acceptance
-      -parallel
-      -coverprofile ./tests/coverage-acceptance.txt
+    - curl -Os https://cli.codecov.io/latest/alpine/codecov
+    - chmod +x codecov
+    - ./codecov upload-process
+      --fail-on-error
+      --git-service github
+      --slug mendersoftware/${CI_PROJECT_NAME}
+      --sha ${CI_COMMIT_SHA}
+      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
+      --file ./tests/coverage-acceptance.txt
+      --flag acceptance
 
 #
 # Alvaldi Helm Rolling release


### PR DESCRIPTION
## Summary
- Replace goveralls/Coveralls with Codecov CLI (`cli.codecov.io`) for coverage reporting
- Use `curlimages/curl-base` image with alpine Codecov binary
- Ticket: QA-1574